### PR TITLE
Searches must be a minimum of 1 character for Fuzzy Search

### DIFF
--- a/jsify.js
+++ b/jsify.js
@@ -169,7 +169,7 @@ $(function() {
 				})
 			});
 			var results = search(commands_list, parsed[0]);
-			if (results.length > 0) {
+			if (results.length > 0 && parsed[0].length > 1) {
 				response = '\nThat command doesn\'t exist. Did you mean ';
 				results.forEach(function(result, index) {
 					if (index === results.length - 1 && results.length == 2) {


### PR DESCRIPTION
Prevents searches of one character like "e" outputting all commands - defaults to the "help" commands list if the user only enters 1 character.