### PR TITLE
Fixed whitespace and optimized fuzzy search

### DIFF
--- a/jsify.js
+++ b/jsify.js
@@ -120,7 +120,7 @@ var lambdify = function(format_string) {
 var options = {
 	include: ["score"],
 	shouldSort: true,
-	threshold: 0.2,
+	threshold: 0.3,
 	location: 0,
 	distance: 100,
 	maxPatternLength: 32,

--- a/jsify.js
+++ b/jsify.js
@@ -118,17 +118,18 @@ var lambdify = function(format_string) {
 }
 
 var options = {
-  include: ["score"],
-  shouldSort: true,
-  threshold: 0.4,
-  location: 0,
-  distance: 100,
-  maxPatternLength: 32,
-  keys: ['command']
+	include: ["score"],
+	shouldSort: true,
+	threshold: 0.2,
+	location: 0,
+	distance: 100,
+	maxPatternLength: 32,
+	keys: ['command']
 };
 
 var search = function(list, searchitem) {
-   return new Fuse(list, options).search(searchitem)
+	options.distance = (searchitem.length<=2? 0 : 100)
+	return new Fuse(list, options).search(searchitem)
 }
 
 $(function() {


### PR DESCRIPTION
Try typing f into the console. The current version gives you "forms, fb, facebook, officers, or info". This commit will give "forms, fb, or facebook". When a user types f into the console, they do not want to see "officers" or "info". The threshold has also been adjusted to make stricter searches